### PR TITLE
feat: add isDark function

### DIFF
--- a/src/contrastInfo.ts
+++ b/src/contrastInfo.ts
@@ -1,3 +1,4 @@
+import { relativeLuminance } from "./relativeLuminance";
 import { IRgbColor } from "./types/rgb";
 
 interface IWCAGInfo {
@@ -9,25 +10,9 @@ interface IWCAGInfo {
   isUIAA: boolean;
 }
 
-/**
- * https://www.w3.org/TR/WCAG20/#relativeluminancedef
- */
-function calculateRelativeLuminance (value: IRgbColor): number {
-  const sR = value.red / 255;
-  const sG = value.green / 255;
-  const sB = value.blue / 255;
-
-  const R = sR <= 0.03928 ? (sR / 12.92) : ((( sR + 0.055) / 1.055) ** 2.4);
-  const G = sG <= 0.03928 ? (sG / 12.92) : ((( sG + 0.055) / 1.055) ** 2.4);
-  const B = sB <= 0.03928 ? (sB / 12.92) : ((( sB + 0.055) / 1.055) ** 2.4);
-
-
-  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
-}
-
 export function contrastInfo(c1: IRgbColor, c2: IRgbColor): IWCAGInfo {
-  const L1 = calculateRelativeLuminance(c1);
-  const L2 = calculateRelativeLuminance(c2);
+  const L1 = relativeLuminance(c1);
+  const L2 = relativeLuminance(c2);
 
   const ratio = (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,5 +36,7 @@ export { formatHsl } from './formatHsl';
 export { formatHsv } from './formatHsv';
 export { formatCmyk } from './formatCmyk';
 export { contrastInfo } from './contrastInfo';
+export { relativeLuminance} from './relativeLuminance';
+export { isDark } from './isDark';
 
 export const version = '__VERSION__';

--- a/src/isDark.ts
+++ b/src/isDark.ts
@@ -1,0 +1,9 @@
+import { relativeLuminance } from "./relativeLuminance";
+import { IRgbColor } from "./types/rgb";
+
+
+export function isDark(value: IRgbColor): boolean {
+  const L = relativeLuminance(value);
+
+  return L < 0.179;
+};

--- a/src/relativeLuminance.ts
+++ b/src/relativeLuminance.ts
@@ -1,0 +1,17 @@
+import { IRgbColor } from "./types/rgb";
+
+/**
+ * https://www.w3.org/TR/WCAG20/#relativeluminancedef
+ */
+export function relativeLuminance(value: IRgbColor): number {
+  const sR = value.red / 255;
+  const sG = value.green / 255;
+  const sB = value.blue / 255;
+
+  const R = sR <= 0.03928 ? (sR / 12.92) : (((sR + 0.055) / 1.055) ** 2.4);
+  const G = sG <= 0.03928 ? (sG / 12.92) : (((sG + 0.055) / 1.055) ** 2.4);
+  const B = sB <= 0.03928 ? (sB / 12.92) : (((sB + 0.055) / 1.055) ** 2.4);
+
+
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+}

--- a/test/isDark.ts
+++ b/test/isDark.ts
@@ -1,0 +1,8 @@
+import { isDark } from '../src/isDark';
+
+test('Checks if a color is dark', () => {
+  expect(isDark({ red: 0, blue: 0, green: 0 })).toBe(true);
+  expect(isDark({ red: 255, blue: 255, green: 255 })).toBe(false);
+
+  expect(isDark({ red: 7, blue: 45, green: 32 })).toBe(true);
+});


### PR DESCRIPTION
This adds `isDark` function to the library, it calculates if color is considered dark based on the [relative luminance defined here](https://www.w3.org/TR/WCAG20/#relativeluminancedef)